### PR TITLE
feat: store login token and add me page

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -22,7 +22,9 @@ export default function LoginPage() {
         password,
       });
 
-      setMessage(result);
+      localStorage.setItem("authToken", result.token);
+
+      setMessage(result.message);
     } catch (err) {
       if (err instanceof Error) {
         setError(err.message);

--- a/src/app/me/page.tsx
+++ b/src/app/me/page.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useState } from "react";
+import { getMe } from "@/lib/api/auth";
+
+export default function MePage() {
+  const [userInfo, setUserInfo] = useState("");
+  const [error, setError] = useState("");
+
+  const handleGetMe = async () => {
+    setUserInfo("");
+    setError("");
+
+    const token = localStorage.getItem("authToken");
+
+    if (!token) {
+      setError("ログイン情報がありません。先にログインしてください。");
+      return;
+    }
+
+    try {
+      const result = await getMe(token);
+
+      setUserInfo(`ID: ${result.id} / Email: ${result.email}`);
+    } catch (err) {
+      if (err instanceof Error) {
+        setError(err.message);
+      } else {
+        setError("failed to fetch me");
+      }
+    }
+  };
+
+  return (
+    <main style={{ padding: 24 }}>
+      <h1>ログイン中ユーザー確認</h1>
+
+      <p>保存したJWTトークンを使って、Goバックエンドの /me を呼び出します。</p>
+
+      <button onClick={handleGetMe}>ログイン中ユーザーを確認する</button>
+
+      {userInfo && <p style={{ color: "green" }}>{userInfo}</p>}
+      {error && <p style={{ color: "red" }}>{error}</p>}
+    </main>
+  );
+}

--- a/src/lib/api/auth.ts
+++ b/src/lib/api/auth.ts
@@ -1,4 +1,5 @@
-const API_BASE_URL = "http://localhost:8080";
+const API_BASE_URL =
+  process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8080";
 
 export type SignupInput = {
   username: string;
@@ -9,6 +10,16 @@ export type SignupInput = {
 export type LoginInput = {
   email: string;
   password: string;
+};
+
+export type LoginResponse = {
+  message: string;
+  token: string;
+};
+
+export type MeResponse = {
+  id: number;
+  email: string;
 };
 
 export async function signup(input: SignupInput): Promise<string> {
@@ -29,7 +40,7 @@ export async function signup(input: SignupInput): Promise<string> {
   return text;
 }
 
-export async function login(input: LoginInput): Promise<string> {
+export async function login(input: LoginInput): Promise<LoginResponse> {
   const response = await fetch(`${API_BASE_URL}/login`, {
     method: "POST",
     headers: {
@@ -38,25 +49,28 @@ export async function login(input: LoginInput): Promise<string> {
     body: JSON.stringify(input),
   });
 
-  const text = await response.text();
+  const data = await response.json();
 
   if (!response.ok) {
-    throw new Error(text || "login failed");
+    throw new Error(data?.message || "login failed");
   }
 
-  return text;
+  return data;
 }
 
-export async function getMe(): Promise<string> {
+export async function getMe(token: string): Promise<MeResponse> {
   const response = await fetch(`${API_BASE_URL}/me`, {
     method: "GET",
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
   });
 
-  const text = await response.text();
+  const data = await response.json();
 
   if (!response.ok) {
-    throw new Error(text || "failed to fetch me");
+    throw new Error(data?.message || "failed to fetch me");
   }
 
-  return text;
+  return data;
 }


### PR DESCRIPTION
## 概要
ログイン成功時にJWTトークンを保存し、保存したトークンを使ってログイン中ユーザー情報を確認できる画面を追加しました。

## 変更内容
- `/login` 成功時にJWTトークンを `localStorage` に保存
- `src/lib/api/auth.ts` の `/login` レスポンスをJWT対応に変更
- `/me` 呼び出し時に `Authorization: Bearer <token>` を送るように変更
- `/me` 画面を追加し、ログイン中ユーザーのIDとメールアドレスを表示

## 動作確認
- `/login` でログイン成功時に `login successful` が表示されることを確認
- `/me` で保存済みJWTトークンを使ってログイン中ユーザー情報を取得できることを確認
- `ID: 7 / Email: frontend-test2@example.com` が表示されることを確認
- `npm run build` 成功