### PR TITLE
feat: add logout page

### DIFF
--- a/src/app/logout/page.tsx
+++ b/src/app/logout/page.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { useState } from "react";
+
+export default function LogoutPage() {
+  const [message, setMessage] = useState("");
+
+  const handleLogout = () => {
+    localStorage.removeItem("authToken");
+    setMessage("ログアウトしました。");
+  };
+
+  return (
+    <main style={{ padding: 24 }}>
+      <h1>ログアウト</h1>
+
+      <p>保存されているログイントークンを削除します。</p>
+
+      <button onClick={handleLogout}>ログアウトする</button>
+
+      {message && <p style={{ color: "green" }}>{message}</p>}
+    </main>
+  );
+}


### PR DESCRIPTION
## 概要
ログアウト用ページを追加しました。

## 変更内容
- `/logout` ページを追加
- ログアウトボタン押下時に `localStorage` の `authToken` を削除
- ログアウト後に `/me` でログイン情報がない状態になることを確認

## 動作確認
- `/login` でログインできることを確認
- `/me` でログイン中ユーザー情報が表示されることを確認
- `/logout` でログアウトできることを確認
- ログアウト後、`/me` で「ログイン情報がありません。先にログインしてください。」が表示されることを確認
- `npm run build` 成功