### PR TITLE
feat: redirect to me page after login

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,9 +1,11 @@
 "use client";
 
 import { useState } from "react";
+import { useRouter } from "next/navigation";
 import { login } from "@/lib/api/auth";
 
 export default function LoginPage() {
+  const router = useRouter();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
 
@@ -25,6 +27,9 @@ export default function LoginPage() {
       localStorage.setItem("authToken", result.token);
 
       setMessage(result.message);
+
+      router.push("/me");
+
     } catch (err) {
       if (err instanceof Error) {
         setError(err.message);


### PR DESCRIPTION
## 概要
ログイン成功後に `/me` ページへ自動遷移するようにしました。

## 変更内容
- `useRouter` を追加
- ログイン成功時にJWTトークンを保存後、`/me` へ遷移する処理を追加

## 動作確認
- `/login` でログインできることを確認
- ログイン成功後に `/me` へ自動遷移することを確認
- `/me` でログイン中ユーザー情報を表示できることを確認
- `npm run build` 成功