### PR TITLE
feat: redirect to login after logout

### DIFF
--- a/src/app/logout/page.tsx
+++ b/src/app/logout/page.tsx
@@ -1,13 +1,16 @@
 "use client";
 
 import { useState } from "react";
+import { useRouter } from "next/navigation";
 
 export default function LogoutPage() {
+  const router = useRouter();
   const [message, setMessage] = useState("");
 
   const handleLogout = () => {
     localStorage.removeItem("authToken");
     setMessage("ログアウトしました。");
+    router.push("/login");
   };
 
   return (


### PR DESCRIPTION
## 概要
ログアウト後にログイン画面へ自動遷移するようにしました。

## 変更内容
- `useRouter` を追加
- ログアウト時に `authToken` を削除後、`/login` へ遷移する処理を追加

## 動作確認
- `/login` でログインできることを確認
- ログイン後に `/me` へ自動遷移することを確認
- `/logout` でログアウト後、`/login` へ自動遷移することを確認
- ログアウト後、`/me` でログイン情報がない状態になることを確認
- `npm run build` 成功