### PR TITLE
feat: auto fetch current user on me page

### DIFF
--- a/src/app/me/page.tsx
+++ b/src/app/me/page.tsx
@@ -1,35 +1,51 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
 import { getMe } from "@/lib/api/auth";
 
 export default function MePage() {
+  const router = useRouter();
+
   const [userInfo, setUserInfo] = useState("");
   const [error, setError] = useState("");
+  const [loading, setLoading] = useState(true);
 
-  const handleGetMe = async () => {
-    setUserInfo("");
-    setError("");
+  useEffect(() => {
+    const fetchMe = async () => {
+      setUserInfo("");
+      setError("");
+      setLoading(true);
 
-    const token = localStorage.getItem("authToken");
+      const token = localStorage.getItem("authToken");
 
-    if (!token) {
-      setError("ログイン情報がありません。先にログインしてください。");
-      return;
-    }
-
-    try {
-      const result = await getMe(token);
-
-      setUserInfo(`ID: ${result.id} / Email: ${result.email}`);
-    } catch (err) {
-      if (err instanceof Error) {
-        setError(err.message);
-      } else {
-        setError("failed to fetch me");
+      if (!token) {
+        setError("ログイン情報がありません。ログイン画面へ移動します。");
+        setLoading(false);
+        router.push("/login");
+        return;
       }
-    }
-  };
+
+      try {
+        const result = await getMe(token);
+        setUserInfo(`ID: ${result.id} / Email: ${result.email}`);
+      } catch (err) {
+        localStorage.removeItem("authToken");
+
+        if (err instanceof Error) {
+          setError(err.message);
+        } else {
+          setError("failed to fetch me");
+        }
+
+        router.push("/login");
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchMe();
+  }, [router]);
 
   return (
     <main style={{ padding: 24 }}>
@@ -37,8 +53,7 @@ export default function MePage() {
 
       <p>保存したJWTトークンを使って、Goバックエンドの /me を呼び出します。</p>
 
-      <button onClick={handleGetMe}>ログイン中ユーザーを確認する</button>
-
+      {loading && <p>確認中です...</p>}
       {userInfo && <p style={{ color: "green" }}>{userInfo}</p>}
       {error && <p style={{ color: "red" }}>{error}</p>}
     </main>


### PR DESCRIPTION
## 概要
`/me` ページ表示時に、保存済みJWTトークンを使ってログイン中ユーザー情報を自動取得するようにしました。

## 変更内容
- `/me` ページで `useEffect` を使ってユーザー情報を自動取得
- 未ログイン時は `/login` に遷移
- 無効なトークンの場合は `authToken` を削除して `/login` に遷移
- 手動確認ボタンを削除

## 動作確認
- `/login` でログイン後、`/me` に自動遷移することを確認
- `/me` でユーザーIDとメールアドレスが自動表示されることを確認
- `/logout` 後に `/me` へアクセスすると `/login` に戻ることを確認
- `npm run build` 成功