### PR TITLE
feat: add auth navigation links

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useState, useEffect } from "react";
 import {
   VStack,
@@ -282,6 +283,21 @@ export default function Home() {
         />
       </VStack>
 
+            <Center>
+        <VStack spacing={2} mb={6}>
+          <Text fontSize="sm" color="gray.600">
+            アカウントメニュー
+          </Text>
+
+          <VStack spacing={2}>
+            <Link href="/signup">新規登録</Link>
+            <Link href="/login">ログイン</Link>
+            <Link href="/me">マイページ</Link>
+            <Link href="/logout">ログアウト</Link>
+          </VStack>
+        </VStack>
+      </Center>
+      
       {!weather && !loading && !isFirstTime && apiKey && (
         <VStack spacing={6}>
           <Center>


### PR DESCRIPTION
## 概要
トップページに認証関連ページへのリンクを追加しました。

## 変更内容
- `/signup` へのリンクを追加
- `/login` へのリンクを追加
- `/me` へのリンクを追加
- `/logout` へのリンクを追加

## 動作確認
- トップページに認証リンクが表示されることを確認
- 新規登録リンクから `/signup` に移動できることを確認
- ログインリンクから `/login` に移動できることを確認
- マイページリンクから `/me` に移動できることを確認
- ログアウトリンクから `/logout` に移動できることを確認
- `npm run build` 成功