### PR TITLE
fix: handle login error response

### DIFF
--- a/src/lib/api/auth.ts
+++ b/src/lib/api/auth.ts
@@ -49,13 +49,13 @@ export async function login(input: LoginInput): Promise<LoginResponse> {
     body: JSON.stringify(input),
   });
 
-  const data = await response.json();
+  const text = await response.text();
 
   if (!response.ok) {
-    throw new Error(data?.message || "login failed");
+    throw new Error(text || "login failed");
   }
 
-  return data;
+  return JSON.parse(text) as LoginResponse;
 }
 
 export async function getMe(token: string): Promise<MeResponse> {


### PR DESCRIPTION
## 概要
ログイン失敗時のエラーレスポンスを正しく表示できるように修正しました。

## 変更内容
- `/login` のレスポンスを一度 text として受け取るように変更
- ログイン失敗時は Goバックエンドのエラーメッセージをそのまま表示
- ログイン成功時のみ JSON としてパースするように変更

## 動作確認
- 正しいメールアドレス・パスワードでログインできることを確認
- 誤ったパスワードで `invalid email or password` が表示されることを確認
- `npm run build` 成功