### PR TITLE
feat: redirect to login after signup

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -6,6 +6,7 @@ import { login } from "@/lib/api/auth";
 
 export default function LoginPage() {
   const router = useRouter();
+
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
 
@@ -29,7 +30,6 @@ export default function LoginPage() {
       setMessage(result.message);
 
       router.push("/me");
-
     } catch (err) {
       if (err instanceof Error) {
         setError(err.message);

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -1,9 +1,11 @@
 "use client";
 
 import { useState } from "react";
+import { useRouter } from "next/navigation";
 import { signup } from "@/lib/api/auth";
 
 export default function SignupPage() {
+  const router = useRouter();
   const [username, setUsername] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
@@ -25,6 +27,7 @@ export default function SignupPage() {
       });
 
       setMessage(result);
+      router.push("/login");
     } catch (err) {
       if (err instanceof Error) {
         setError(err.message);


### PR DESCRIPTION
## 概要
新規登録成功後にログイン画面へ自動遷移するようにしました。

## 変更内容
- `/signup` 成功後に `/login` へ遷移する処理を追加
- `useRouter` を追加
- `/login` ページがログイン画面として表示されるように修正

## 動作確認
- 新しいメールアドレスで新規登録できることを確認
- 新規登録成功後に `/login` へ自動遷移することを確認
- `/login` でログイン画面が表示されることを確認
- ログイン後に `/me` へ遷移し、ユーザー情報が表示されることを確認
- `npm run build` 成功