### PR TITLE
fix: improve responsive header title

### DIFF
--- a/src/components/organisms/Header/Header.tsx
+++ b/src/components/organisms/Header/Header.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { HStack, Heading, Icon, Box } from "@chakra-ui/react";
+import { HStack, Heading, Icon, Box, Text, VStack } from "@chakra-ui/react";
 import { BsHouseDoor, BsGear } from "react-icons/bs";
 import { MdOutlineWbSunny, MdOutlineCheckroom } from "react-icons/md";
 import { Button } from "../../atoms";
@@ -14,12 +14,18 @@ interface HeaderProps {
 export const Header = ({
   showHomeButton = false,
   onHomeClick,
-  onSettingsClick
+  onSettingsClick,
 }: HeaderProps) => {
   return (
-    <HStack w="full" justify="space-between" minH="40px">
+    <HStack
+      w="full"
+      justify="space-between"
+      align="center"
+      minH="40px"
+      gap={{ base: 2, md: 4 }}
+    >
       {/* 左側：ホームボタン（天気表示時のみ） */}
-      <Box>
+      <Box minW={{ base: "64px", md: "88px" }}>
         {showHomeButton && (
           <Button
             variant="outline"
@@ -34,22 +40,47 @@ export const Header = ({
       </Box>
 
       {/* 中央：タイトル */}
-      <Heading 
-        size="xl" 
-        textAlign="center" 
-        color="gray.800"
-        display="flex"
-        alignItems="center"
-        gap={3}
+      <HStack
+        as="header"
         flex="1"
+        justify="center"
+        align="center"
+        spacing={{ base: 2, md: 3 }}
+        minW={0}
       >
-        <Icon as={MdOutlineWbSunny} color="orange.400" />
-        天気に応じた服装提案アプリ
-        <Icon as={MdOutlineCheckroom} color="blue.400" />
-      </Heading>
+        <Icon
+          as={MdOutlineWbSunny}
+          color="orange.400"
+          boxSize={{ base: 6, md: 9 }}
+          flexShrink={0}
+        />
+
+        <Heading
+          as="h1"
+          textAlign="center"
+          color="gray.800"
+          fontSize={{ base: "2xl", sm: "3xl", md: "4xl" }}
+          lineHeight={{ base: "1.25", md: "1.2" }}
+          letterSpacing="tight"
+          wordBreak="keep-all"
+          whiteSpace={{ base: "normal", md: "normal" }}
+        >
+          <VStack as="span" spacing={0} display="inline-flex">
+            <Text as="span">天気に応じた服装</Text>
+            <Text as="span">提案アプリ</Text>
+          </VStack>
+        </Heading>
+
+        <Icon
+          as={MdOutlineCheckroom}
+          color="blue.400"
+          boxSize={{ base: 6, md: 9 }}
+          flexShrink={0}
+        />
+      </HStack>
 
       {/* 右側：設定ボタン */}
-      <Box>
+      <Box minW={{ base: "64px", md: "88px" }} textAlign="right">
         <Button
           variant="outline"
           size="sm"


### PR DESCRIPTION
## 概要
スマホ表示時にヘッダータイトルが1文字ずつ縦に折り返される問題を修正しました。

## 変更内容
- タイトルを2行表示に調整
- `wordBreak="keep-all"` を追加
- スマホ幅でのタイトル・アイコンサイズを調整
- 左右ボタン幅をそろえて中央タイトルが崩れにくいように修正

## 動作確認
- PC幅でタイトルが自然に表示されることを確認
- スマホ幅でタイトルが縦書きのように崩れないことを確認
- `npm run build` 成功